### PR TITLE
Fix 2 descriptions

### DIFF
--- a/api/endpoints/auth_reset_me.md
+++ b/api/endpoints/auth_reset_me.md
@@ -1,6 +1,6 @@
 # auth/reset/me Endpoint
 
-The auth/reset/me endpoint will invalidate your login.
+The auth/reset/me endpoint will send you a request to change your password via mail.
 
 ### Endpoint
 

--- a/api/events/backend_events/ban.md
+++ b/api/events/backend_events/ban.md
@@ -1,6 +1,6 @@
 # Ban message
 
-Event passed when a person is banned
+Event passed when you are banned from a room.
 
 **Note**: the ban duration offers you the following three options.
 


### PR DESCRIPTION
This PR does fix two incorrect/vague descriptions of what the endpoint [auth/reset/me](https://github.com/plugcommunity/documentation/blob/staging/api/endpoints/auth_reset_me.md) and the event [ban](https://github.com/plugcommunity/documentation/blob/staging/api/events/backend_events/ban.md) do.
