### PR TITLE
Fix links syntax for Github's new markdown renderer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ patched or fixed.
 
 ### Contributors
 
-* [Alex (thedark1337)]          (https://github.com/thedark1337)
-* [Henchman (hunchmun)]         (https://github.com/hunchmun)
-* [houdhakker2]                 (https://github.com/houdhakker2)
-* [IgorAntun]                   (https://github.com/IgorAntun)
-* [Marvin (xBytez)]             (https://github.com/xBytez)
-* [René Kooi (goto-bus-stop)]   (https://github.com/goto-bus-stop)
-* [SooYou]                      (https://github.com/SooYou)
+* [Alex (thedark1337)](https://github.com/thedark1337)
+* [Henchman (hunchmun)](https://github.com/hunchmun)
+* [houdhakker2](https://github.com/houdhakker2)
+* [IgorAntun](https://github.com/IgorAntun)
+* [Marvin (xBytez)](https://github.com/xBytez)
+* [Renée Kooi (goto-bus-stop)](https://github.com/goto-bus-stop)
+* [SooYou](https://github.com/SooYou)
 
 Thank you for making this project possible by contributing!
 

--- a/api/endpoints/README.md
+++ b/api/endpoints/README.md
@@ -16,67 +16,67 @@ Some methods however, are white listed such as chat deleting, this is in order t
 
 ### List of endpoints
 
-| Endpoint Name             | Link                                                                                     |
-|-----------------------    | -------------                                                                            |
-| Auth Facebook             | "[auth/facebook]                 (/api/endpoints/auth_facebook.md)"                      |
-| Auth Login                | "[auth/login]                    (/api/endpoints/auth_login.md)"                         |
-| Auth Reset                | "[auth/reset/me]                 (/api/endpoints/auth_reset_me.md)"                      |
-| Auth Session              | "[auth/session]                  (/api/endpoints/auth_session.md)"                       |
-| Auth Token                | "[auth/token]                    (/api/endpoints/auth_token.md)"                         |
-| Bans                      | "[bans]                          (/api/endpoints/bans.md)"                               |
-| Bans Add                  | "[bans/add]                      (/api/endpoints/bans_add.md)"                           |
-| Booth                     | "[booth]                         (/api/endpoints/booth.md)"                              |
-| Booth Add                 | "[booth/add]                     (/api/endpoints/booth_add.md)"                          |
-| Booth Cycle               | "[booth/cycle]                   (/api/endpoints/booth_cycle.md)"                        |
-| Booth Lock                | "[booth/lock]                    (/api/endpoints/booth_lock.md)"                         |
-| Booth Move                | "[booth/move]                    (/api/endpoints/booth_move.md)"                         |
-| Booth Remove              | "[booth/remove/:id]              (/api/endpoints/booth_remove.md)"                       |
-| Booth Skip                | "[booth/skip]                    (/api/endpoints/booth_skip.md)"                         |
-| Booth Skip Me             | "[booth/skip/me]                 (/api/endpoints/booth_skip_me.md)"                      |
-| Chat Delete               | "[chat/:cid]                     (/api/endpoints/chat_cid.md)"                           |
-| Friends                   | "[friends]                       (/api/endpoints/friends.md)"                            |
-| Friends Ignore            | "[friends/ignore]                (/api/endpoints/friends_ignore.md)"                     |
-| Friends Invites           | "[friends/invites]               (/api/endpoints/friends_invites.md)"                    |
-| Grabs                     | "[grabs]                         (/api/endpoints/grabs.md)"                              |
-| Ignores                   | "[ignores]                       (/api/endpoints/ignores.md)"                            |
-| Mutes                     | "[mutes]                         (/api/endpoints/mutes.md)"                              |
-| News                      | "[news]                          (/api/endpoints/news.md)"                               |
-| Notifications             | "[notifications]                 (/api/endpoints/notifications.md)"                      |
-| Playlists                 | "[playlists]                     (/api/endpoints/playlists.md)"                          |
-| Playlists Activate        | "[playlists/:id/activate]        (/api/endpoints/playlists_id_activate.md)"              |
-| Playlists Media Delete    | "[playlists/:id/media/delete]    (/api/endpoints/playlists_id_media_delete.md)"          |
-| Playlists Media Insert    | "[playlists/:id/media/insert]    (/api/endpoints/playlists_id_media_insert.md)"          |
-| Playlists Media Move      | "[playlists/:id/media/move]      (/api/endpoints/playlists_id_media_move.md)"            |
-| Playlists Media Update    | "[playlists/:id/media/update]    (/api/endpoints/playlists_id_media_update.md)"          |
-| Playlists Rename          | "[playlists/:id/rename]          (/api/endpoints/playlists_id_rename.md)"                |
-| Playlists Shuffle         | "[playlists/:id/shuffle]         (/api/endpoints/playlists_id_shuffle.md)"               |
-| Playlists Media           | "[playlists/:id/media]           (/api/endpoints/playlists_media.md)"                    |
-| Profile Blurb             | "[profile/blurb]                 (/api/endpoints/profile_blurb.md)"                      |
-| Rooms                     | "[rooms]                         (/api/endpoints/rooms.md)"                              |
-| Rooms Favorites           | "[rooms/favorites]               (/api/endpoints/rooms_favorites.md)"                    |
-| Rooms History             | "[rooms/history]                 (/api/endpoints/rooms_history.md)"                      |
-| Rooms Join                | "[rooms/join]                    (/api/endpoints/rooms_join.md)"                         |
-| Rooms Me                  | "[rooms/me]                      (/api/endpoints/rooms_me.md)"                           |
-| Rooms SOS                 | "[rooms/sos]                     (/api/endpoints/rooms_sos.md)"                          |
-| Rooms State               | "[rooms/state]                   (/api/endpoints/rooms_state.md)"                        |
-| Rooms Update              | "[rooms/update]                  (/api/endpoints/rooms_update.md)"                       |
-| Rooms Validate            | "[rooms/validate]                (/api/endpoints/rooms_validate.md)"                     |
-| Staff                     | "[staff]                         (/api/endpoints/staff.md)"                              |
-| Staff Update              | "[staff/update]                  (/api/endpoints/staff_update.md)"                       |
-| Store Inventory           | "[store/inventory]               (/api/endpoints/store_inventory.md)"                    |
-| Store Products            | "[store/products]                (/api/endpoints/store_products.md)"                     |
-| Store Purchase            | "[store/purchase]                (/api/endpoints/store_purchase.md)"                     |
-| Store Purchase Username   | "[store/purchase/username]       (/api/endpoints/store_purchase_username.md)"            |
-| Users                     | "[users]                         (/api/endpoints/users.md)"                              |
-| Users Avatar              | "[users/avatar]                  (/api/endpoints/users_avatar.md)"                       |
-| Users Badge               | "[users/badge]                   (/api/endpoints/users_badge.md)"                        |
-| Users Bulk                | "[users/bulk]                    (/api/endpoints/users_bulk.md)"                         |
-| Users Language            | "[users/language]                (/api/endpoints/users_language.md)"                     |
-| Users Me                  | "[users/me]                      (/api/endpoints/users_me.md)"                           |
-| Users Me History          | "[users/me/history]              (/api/endpoints/users_me_history.md)"                   |
-| Users Me Transactions     | "[users/me/transactions]         (/api/endpoints/users_me_transactions.md)"              |
-| Users Settings            | "[users/settings]                (/api/endpoints/users_settings.md)"                     |
-| Users Validate            | "[users/validate]                (/api/endpoints/users_validate.md)"                     |
-| Votes                     | "[votes]                         (/api/endpoints/votes.md)"                              |
+| Endpoint Name             | Link                                                                        |
+|---------------------------|-----------------------------------------------------------------------------|
+| Auth Facebook             | "[auth/facebook](/api/endpoints/auth_facebook.md)"                          |
+| Auth Login                | "[auth/login](/api/endpoints/auth_login.md)"                                |
+| Auth Reset                | "[auth/reset/me](/api/endpoints/auth_reset_me.md)"                          |
+| Auth Session              | "[auth/session](/api/endpoints/auth_session.md)"                            |
+| Auth Token                | "[auth/token](/api/endpoints/auth_token.md)"                                |
+| Bans                      | "[bans](/api/endpoints/bans.md)"                                            |
+| Bans Add                  | "[bans/add](/api/endpoints/bans_add.md)"                                    |
+| Booth                     | "[booth](/api/endpoints/booth.md)"                                          |
+| Booth Add                 | "[booth/add](/api/endpoints/booth_add.md)"                                  |
+| Booth Cycle               | "[booth/cycle](/api/endpoints/booth_cycle.md)"                              |
+| Booth Lock                | "[booth/lock](/api/endpoints/booth_lock.md)"                                |
+| Booth Move                | "[booth/move](/api/endpoints/booth_move.md)"                                |
+| Booth Remove              | "[booth/remove/:id](/api/endpoints/booth_remove.md)"                        |
+| Booth Skip                | "[booth/skip](/api/endpoints/booth_skip.md)"                                |
+| Booth Skip Me             | "[booth/skip/me](/api/endpoints/booth_skip_me.md)"                          |
+| Chat Delete               | "[chat/:cid](/api/endpoints/chat_cid.md)"                                   |
+| Friends                   | "[friends](/api/endpoints/friends.md)"                                      |
+| Friends Ignore            | "[friends/ignore](/api/endpoints/friends_ignore.md)"                        |
+| Friends Invites           | "[friends/invites](/api/endpoints/friends_invites.md)"                      |
+| Grabs                     | "[grabs](/api/endpoints/grabs.md)"                                          |
+| Ignores                   | "[ignores](/api/endpoints/ignores.md)"                                      |
+| Mutes                     | "[mutes](/api/endpoints/mutes.md)"                                          |
+| News                      | "[news](/api/endpoints/news.md)"                                            |
+| Notifications             | "[notifications](/api/endpoints/notifications.md)"                          |
+| Playlists                 | "[playlists](/api/endpoints/playlists.md)"                                  |
+| Playlists Activate        | "[playlists/:id/activate](/api/endpoints/playlists_id_activate.md)"         |
+| Playlists Media Delete    | "[playlists/:id/media/delete](/api/endpoints/playlists_id_media_delete.md)" |
+| Playlists Media Insert    | "[playlists/:id/media/insert](/api/endpoints/playlists_id_media_insert.md)" |
+| Playlists Media Move      | "[playlists/:id/media/move](/api/endpoints/playlists_id_media_move.md)"     |
+| Playlists Media Update    | "[playlists/:id/media/update](/api/endpoints/playlists_id_media_update.md)" |
+| Playlists Rename          | "[playlists/:id/rename](/api/endpoints/playlists_id_rename.md)"             |
+| Playlists Shuffle         | "[playlists/:id/shuffle](/api/endpoints/playlists_id_shuffle.md)"           |
+| Playlists Media           | "[playlists/:id/media](/api/endpoints/playlists_media.md)"                  |
+| Profile Blurb             | "[profile/blurb](/api/endpoints/profile_blurb.md)"                          |
+| Rooms                     | "[rooms](/api/endpoints/rooms.md)"                                          |
+| Rooms Favorites           | "[rooms/favorites](/api/endpoints/rooms_favorites.md)"                      |
+| Rooms History             | "[rooms/history](/api/endpoints/rooms_history.md)"                          |
+| Rooms Join                | "[rooms/join](/api/endpoints/rooms_join.md)"                                |
+| Rooms Me                  | "[rooms/me](/api/endpoints/rooms_me.md)"                                    |
+| Rooms SOS                 | "[rooms/sos](/api/endpoints/rooms_sos.md)"                                  |
+| Rooms State               | "[rooms/state](/api/endpoints/rooms_state.md)"                              |
+| Rooms Update              | "[rooms/update](/api/endpoints/rooms_update.md)"                            |
+| Rooms Validate            | "[rooms/validate](/api/endpoints/rooms_validate.md)"                        |
+| Staff                     | "[staff](/api/endpoints/staff.md)"                                          |
+| Staff Update              | "[staff/update](/api/endpoints/staff_update.md)"                            |
+| Store Inventory           | "[store/inventory](/api/endpoints/store_inventory.md)"                      |
+| Store Products            | "[store/products](/api/endpoints/store_products.md)"                        |
+| Store Purchase            | "[store/purchase](/api/endpoints/store_purchase.md)"                        |
+| Store Purchase Username   | "[store/purchase/username](/api/endpoints/store_purchase_username.md)"      |
+| Users                     | "[users](/api/endpoints/users.md)"                                          |
+| Users Avatar              | "[users/avatar](/api/endpoints/users_avatar.md)"                            |
+| Users Badge               | "[users/badge](/api/endpoints/users_badge.md)"                              |
+| Users Bulk                | "[users/bulk](/api/endpoints/users_bulk.md)"                                |
+| Users Language            | "[users/language](/api/endpoints/users_language.md)"                        |
+| Users Me                  | "[users/me](/api/endpoints/users_me.md)"                                    |
+| Users Me History          | "[users/me/history](/api/endpoints/users_me_history.md)"                    |
+| Users Me Transactions     | "[users/me/transactions](/api/endpoints/users_me_transactions.md)"          |
+| Users Settings            | "[users/settings](/api/endpoints/users_settings.md)"                        |
+| Users Validate            | "[users/validate](/api/endpoints/users_validate.md)"                        |
+| Votes                     | "[votes](/api/endpoints/votes.md)"                                          |
 
 *Ordered by Endpoint Name^

--- a/api/events/backend_events/README.md
+++ b/api/events/backend_events/README.md
@@ -6,47 +6,47 @@ possible.
 
 ### List of emitted events
 
-| Event Name                | Link                                                                                          |
-|-----------------------    | -------------                                                                                 |
-| Ack                       | "[ack]                           (/api/events/backend_events/ack.md)"                         |
-| Advance                   | "[advance]                       (/api/events/advance.md#backend)"                            |
-| Ban                       | "[ban]                           (/api/events/backend_events/ban.md)"                         |
-| Chat                      | "[chat]                          (/api/events/chat.md#backend)"                               |
-| ChatDelete                | "[chatDelete]                    (/api/events/backend_events/chatDelete.md)"                  |
-| DJ List Cycle             | "[djListCycle]                   (/api/events/backend_events/djListCycle.md)"                 |
-| DJ List Locked            | "[djListLocked]                  (/api/events/backend_events/djListLocked.md)"                |
-| DJ List Update            | "[djListUpdate]                  (/api/events/djListUpdate.md#backend)"                       |
-| Earn                      | "[earn]                          (/api/events/backend_events/earn.md)"                        |
-| Flood API                 | "[floodAPI]                      (/api/events/backend_events/floodAPI.md)"                    |
-| Flood Chat                | "[floodChat]                     (/api/events/backend_events/floodChat.md)"                   |
-| Friend Accept             | "[friendAccept]                  (/api/events/backend_events/friendAccept.md)"                |
-| Friend Request            | "[friendRequest]                 (/api/events/backend_events/friendRequest.md)"               |
-| Gifted                    | "[gifted]                        (/api/events/backend_events/gifted.md)"                      |
-| Grab                      | "[grab]                          (/api/events/grab.md#backend)"                               |
-| Kill Session              | "[killSession]                   (/api/events/backend_events/killSession.md)"                 |
-| Level Up                  | "[levelUp]                       (/api/events/backend_events/levelUp.md)"                     |
-| Mod Add DJ                | "[modAddDJ]                      (/api/events/backend_events/modAddDJ.md)"                    |
-| Mod Ban                   | "[modBan]                        (/api/events/backend_events/modBan.md)"                      |
-| Mod Move DJ               | "[modMoveDJ]                     (/api/events/backend_events/modMoveDJ.md)"                   |
-| Mod Mute                  | "[modMute]                       (/api/events/backend_events/modMute.md)"                     |
-| Mod Remove DJ             | "[modRemoveDJ]                   (/api/events/backend_events/modRemoveDJ.md)"                 |
-| Mod Skip                  | "[modSkip]                       (/api/events/mod_skip.md#backend)"                           |
-| Mod Staff                 | "[modStaff]                      (/api/events/backend_events/modStaff.md)"                    |
-| Name Changed              | "[nameChanged]                   (/api/events/backend_events/nameChanged.md)"                 |
-| Notify                    | "[notify]                        (/api/events/backend_events/notify.md)"                      |
-| Playlist Cycle            | "[playlistCycle]                 (/api/events/backend_events/playlistCycle.md)"               |
-| Plug Maintenance          | "[plugMaintenance]               (/api/events/backend_events/plugMaintenance.md)"             |
-| Plug Maintenance Alert    | "[plugMaintenanceAlert]          (/api/events/backend_events/plugMaintenanceAlert.md)"        |
-| Plug Message              | "[plugMessage]                   (/api/events/backend_events/plugMessage.md)"                 |
-| Rate Limit                | "[rateLimit]                     (/api/events/backend_events/rateLimit.md)"                   |
-| Room Description Update   | "[roomDescription]               (/api/events/backend_events/roomDescription.md)"             |
-| Room Min Chat Level Update| "[roomMinChatLevelUpdate]        (/api/events/backend_events/roomMinChatLevelUpdate.md)"      |
-| Room Name Update          | "[roomNameUpdate]                (/api/events/backend_events/roomNameUpdate.md)"              |
-| Room Welcome Update       | "[roomWelcomeUpdate]             (/api/events/backend_events/roomWelcomeUpdate.md)"           |
-| Skip                      | "[skip]                          (/api/events/user_skip.md#backend)"                          |
-| User Join                 | "[userJoin]                      (/api/events/user_join.md#backend)"                          |
-| User Leave                | "[userLeave]                     (/api/events/user_leave.md#backend)"                         |
-| User Update               | "[userUpdate]                    (/api/events/backend_events/userUpdate.md)"                  |
-| Vote                      | "[vote]                          (/api/events/vote.md#backend)"                               |
+| Event Name                | Link                                                                             |
+|---------------------------|----------------------------------------------------------------------------------|
+| Ack                       | "[ack](/api/events/backend_events/ack.md)"                                       |
+| Advance                   | "[advance](/api/events/advance.md#backend)"                                      |
+| Ban                       | "[ban](/api/events/backend_events/ban.md)"                                       |
+| Chat                      | "[chat](/api/events/chat.md#backend)"                                            |
+| ChatDelete                | "[chatDelete](/api/events/backend_events/chatDelete.md)"                         |
+| DJ List Cycle             | "[djListCycle](/api/events/backend_events/djListCycle.md)"                       |
+| DJ List Locked            | "[djListLocked](/api/events/backend_events/djListLocked.md)"                     |
+| DJ List Update            | "[djListUpdate](/api/events/djListUpdate.md#backend)"                            |
+| Earn                      | "[earn](/api/events/backend_events/earn.md)"                                     |
+| Flood API                 | "[floodAPI](/api/events/backend_events/floodAPI.md)"                             |
+| Flood Chat                | "[floodChat](/api/events/backend_events/floodChat.md)"                           |
+| Friend Accept             | "[friendAccept](/api/events/backend_events/friendAccept.md)"                     |
+| Friend Request            | "[friendRequest](/api/events/backend_events/friendRequest.md)"                   |
+| Gifted                    | "[gifted](/api/events/backend_events/gifted.md)"                                 |
+| Grab                      | "[grab](/api/events/grab.md#backend)"                                            |
+| Kill Session              | "[killSession](/api/events/backend_events/killSession.md)"                       |
+| Level Up                  | "[levelUp](/api/events/backend_events/levelUp.md)"                               |
+| Mod Add DJ                | "[modAddDJ](/api/events/backend_events/modAddDJ.md)"                             |
+| Mod Ban                   | "[modBan](/api/events/backend_events/modBan.md)"                                 |
+| Mod Move DJ               | "[modMoveDJ](/api/events/backend_events/modMoveDJ.md)"                           |
+| Mod Mute                  | "[modMute](/api/events/backend_events/modMute.md)"                               |
+| Mod Remove DJ             | "[modRemoveDJ](/api/events/backend_events/modRemoveDJ.md)"                       |
+| Mod Skip                  | "[modSkip](/api/events/mod_skip.md#backend)"                                     |
+| Mod Staff                 | "[modStaff](/api/events/backend_events/modStaff.md)"                             |
+| Name Changed              | "[nameChanged](/api/events/backend_events/nameChanged.md)"                       |
+| Notify                    | "[notify](/api/events/backend_events/notify.md)"                                 |
+| Playlist Cycle            | "[playlistCycle](/api/events/backend_events/playlistCycle.md)"                   |
+| Plug Maintenance          | "[plugMaintenance](/api/events/backend_events/plugMaintenance.md)"               |
+| Plug Maintenance Alert    | "[plugMaintenanceAlert](/api/events/backend_events/plugMaintenanceAlert.md)"     |
+| Plug Message              | "[plugMessage](/api/events/backend_events/plugMessage.md)"                       |
+| Rate Limit                | "[rateLimit](/api/events/backend_events/rateLimit.md)"                           |
+| Room Description Update   | "[roomDescription](/api/events/backend_events/roomDescription.md)"               |
+| Room Min Chat Level Update| "[roomMinChatLevelUpdate](/api/events/backend_events/roomMinChatLevelUpdate.md)" |
+| Room Name Update          | "[roomNameUpdate](/api/events/backend_events/roomNameUpdate.md)"                 |
+| Room Welcome Update       | "[roomWelcomeUpdate](/api/events/backend_events/roomWelcomeUpdate.md)"           |
+| Skip                      | "[skip](/api/events/user_skip.md#backend)"                                       |
+| User Join                 | "[userJoin](/api/events/user_join.md#backend)"                                   |
+| User Leave                | "[userLeave](/api/events/user_leave.md#backend)"                                 |
+| User Update               | "[userUpdate](/api/events/backend_events/userUpdate.md)"                         |
+| Vote                      | "[vote](/api/events/vote.md#backend)"                                            |
 
 *Ordered by Event Name^


### PR DESCRIPTION
Github recently changed their markdown renderer, and it no longer
supports having whitespace between the link title and the link URL.